### PR TITLE
Refactor ECS iteration: add range-based ECSView, world iterators and split Archetype/Iterator internals

### DIFF
--- a/editor/Project.cpp
+++ b/editor/Project.cpp
@@ -16,7 +16,6 @@
 #include <Game-Engine/AssetManagerView.hpp>
 
 #include <cassert>
-#include <ranges>
 #include <string>
 #include <utility>
 
@@ -69,11 +68,12 @@ Project::Project()
 
 GE::Game::Descriptor Project::gameDescriptor() const
 {
+    std::map<std::string, GE::Scene::Descriptor> scenes;
+    for (const auto& [sceneId, sceneDesc] : m_scenes)
+        scenes.insert(std::make_pair(sceneDesc.name, sceneDesc));
+
     return {
-        .scenes =  std::map<std::string, GE::Scene::Descriptor>(
-            std::from_range,
-            m_scenes | std::views::transform([](const auto& pair){ return std::make_pair(pair.second.name, pair.second); })
-        ),
+        .scenes = scenes,
         .activeScene = startScene().second.name
     };
 }

--- a/editor/UI/SceneGraphPanel.cpp
+++ b/editor/UI/SceneGraphPanel.cpp
@@ -31,10 +31,12 @@ void SceneGraphPanel::render()
         {
             if (m_scene)
             {
-                GE::ECSView<GE::NameComponent>(&m_scene->ecsWorld()).onEach([&](GE::Entity entity, GE::NameComponent&) {
+                for (GE::ECSWorld::EntityID entityId : m_scene->ecsWorld() | GE::ECSView<GE::NameComponent>())
+                {
+                    GE::Entity entity = { .world = &m_scene->ecsWorld(), .entityId = entityId };
                     if (entity.parent().has_value() == false)
                         renderEntityRow(entity);
-                });
+                }
             }
             else
             {

--- a/include/Game-Engine/ECSView.hpp
+++ b/include/Game-Engine/ECSView.hpp
@@ -11,22 +11,251 @@
 #define ECSVIEW_HPP
 
 #include "Game-Engine/ECSWorld.hpp"
-#include "Game-Engine/Entity.hpp"
 
-#include <functional>
-#include <set>
-#include <cstdint>
 #include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <ranges>
+#include <set>
+#include <tuple>
 #include <type_traits>
 
 namespace GE
 {
 
-template<ECSWorldLike ECSWorldT, Component... Cs> requires(sizeof...(Cs) > 0)
-class basic_ecsView
+template<ECSWorldLike ECSWorldT, Component... Cs>
+struct ecs_view_item
 {
+    template<typename C>
+    using ComponentReference = std::conditional_t<std::is_const_v<ECSWorldT>, const C&, C&>;
+
+    ECSWorldT* world = nullptr;
+    typename ECSWorldT::EntityID entityId = INVALID_ENTITY_ID;
+    std::tuple<ComponentReference<Cs>...> components;
+
+    ecs_view_item(ECSWorldT* w, typename ECSWorldT::EntityID id, ComponentReference<Cs>... cs)
+        : world(w)
+        , entityId(id)
+        , components(cs...)
+    {
+    }
+
+    inline operator typename ECSWorldT::EntityID() const { return entityId; }
+
+};
+
+template<std::size_t I, ECSWorldLike ECSWorldT, Component... Cs>
+inline auto& get(const ecs_view_item<ECSWorldT, Cs...>& item)
+{
+    return std::get<I>(item.components);
+}
+
+template<ECSWorldLike ECSWorldT, Component... Cs> requires(sizeof...(Cs) > 0)
+class basic_ecsView : public std::ranges::view_interface<basic_ecsView<ECSWorldT, Cs...>>
+{
+private:
+    using ArchetypeIterator = std::conditional_t<
+        std::is_const_v<ECSWorldT>,
+        typename decltype(std::declval<const ECSWorld&>().m_archetypes)::const_iterator,
+        typename decltype(std::declval<ECSWorld&>().m_archetypes)::iterator>;
+
 public:
-    basic_ecsView(ECSWorldT* world)
+    using value_type = ecs_view_item<ECSWorldT, Cs...>;
+    class iterator;
+    class reverse_iterator;
+    using const_iterator = iterator;
+    using const_reverse_iterator = reverse_iterator;
+
+    class iterator
+    {
+    public:
+        using iterator_concept = std::input_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = ecs_view_item<ECSWorldT, Cs...>;
+
+        iterator() = default;
+
+        iterator(ECSWorldT* world,
+            const std::set<typename ECSWorldT::ComponentID>* predicate,
+            ArchetypeIterator arch,
+            ArchetypeIterator archEnd)
+            : m_world(world)
+            , m_predicate(predicate)
+            , m_archetypeIt(arch)
+            , m_archetypeEnd(archEnd)
+        {
+            advanceUntilMatch();
+        }
+
+        inline value_type operator*() const
+        {
+            auto& archetype = m_archetypeIt->second;
+            return value_type(
+                m_world,
+                *m_componentIt,
+                *archetype.template getComponentPointer<Cs>(m_componentIt.index())...
+            );
+        }
+
+        inline iterator& operator++()
+        {
+            ++m_componentIt;
+            advanceUntilMatch();
+            return *this;
+        }
+
+        inline void operator++(int) { ++(*this); }
+
+        inline bool operator==(std::default_sentinel_t) const { return m_archetypeIt == m_archetypeEnd; }
+
+    private:
+        ECSWorldT* m_world = nullptr;
+        const std::set<typename ECSWorldT::ComponentID>* m_predicate = nullptr;
+        ArchetypeIterator m_archetypeIt;
+        ArchetypeIterator m_archetypeEnd;
+        using ArchetypeType = std::remove_const_t<typename ArchetypeIterator::value_type::second_type>;
+        using ComponentIterator = std::conditional_t<std::is_const_v<ECSWorldT>, typename ArchetypeType::const_iterator, typename ArchetypeType::iterator>;
+        ComponentIterator m_componentIt;
+        ComponentIterator m_componentEnd;
+
+        inline void advanceUntilMatch()
+        {
+            while (m_archetypeIt != m_archetypeEnd)
+            {
+                if (!std::ranges::includes(m_archetypeIt->first, *m_predicate))
+                {
+                    ++m_archetypeIt;
+                    m_componentIt = {};
+                    m_componentEnd = {};
+                    continue;
+                }
+
+                if (m_componentIt == ComponentIterator())
+                {
+                    if constexpr (std::is_const_v<ECSWorldT>)
+                    {
+                        m_componentIt = m_archetypeIt->second.cbegin();
+                        m_componentEnd = m_archetypeIt->second.cend();
+                    }
+                    else
+                    {
+                        m_componentIt = m_archetypeIt->second.begin();
+                        m_componentEnd = m_archetypeIt->second.end();
+                    }
+                }
+
+                if (m_componentIt != m_componentEnd)
+                    break;
+
+                ++m_archetypeIt;
+                m_componentIt = {};
+                m_componentEnd = {};
+            }
+        }
+    };
+
+    class reverse_iterator
+    {
+    public:
+        using iterator_concept = std::input_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = ecs_view_item<ECSWorldT, Cs...>;
+
+        reverse_iterator() = default;
+
+        reverse_iterator(ECSWorldT* world,
+            const std::set<typename ECSWorldT::ComponentID>* predicate,
+            ArchetypeIterator archBegin,
+            ArchetypeIterator archEnd)
+            : m_world(world)
+            , m_predicate(predicate)
+            , m_archetypeBegin(archBegin)
+            , m_archetypeIt(archEnd)
+        {
+            if (m_archetypeBegin == archEnd)
+                return;
+
+            --m_archetypeIt;
+            m_componentIdx = m_archetypeIt->second.size() > 0 ? m_archetypeIt->second.size() - 1 : 0;
+            retreatUntilMatch();
+        }
+
+        inline value_type operator*() const
+        {
+            auto& archetype = m_archetypeIt->second;
+            return value_type(
+                m_world,
+                archetype.getEntityID(m_componentIdx),
+                *archetype.template getComponentPointer<Cs>(m_componentIdx)...
+            );
+        }
+
+        inline reverse_iterator& operator++()
+        {
+            if (m_isEnd)
+                return *this;
+
+            if (m_componentIdx > 0)
+            {
+                --m_componentIdx;
+                return *this;
+            }
+
+            if (m_archetypeIt == m_archetypeBegin)
+            {
+                m_isEnd = true;
+                return *this;
+            }
+
+            --m_archetypeIt;
+            m_componentIdx = m_archetypeIt->second.size() > 0 ? m_archetypeIt->second.size() - 1 : 0;
+            retreatUntilMatch();
+            return *this;
+        }
+
+        inline void operator++(int) { ++(*this); }
+
+        inline bool operator==(std::default_sentinel_t) const { return m_isEnd; }
+
+    private:
+        ECSWorldT* m_world = nullptr;
+        const std::set<typename ECSWorldT::ComponentID>* m_predicate = nullptr;
+        ArchetypeIterator m_archetypeBegin;
+        ArchetypeIterator m_archetypeIt;
+        uint64_t m_componentIdx = 0;
+        bool m_isEnd = true;
+
+        inline void retreatUntilMatch()
+        {
+            while (true)
+            {
+                if (std::ranges::includes(m_archetypeIt->first, *m_predicate))
+                {
+                    if (m_archetypeIt->second.size() > 0 && m_componentIdx < m_archetypeIt->second.size())
+                    {
+                        m_isEnd = false;
+                        return;
+                    }
+                }
+
+                if (m_archetypeIt == m_archetypeBegin)
+                {
+                    m_isEnd = true;
+                    return;
+                }
+
+                --m_archetypeIt;
+                m_componentIdx = m_archetypeIt->second.size() > 0 ? m_archetypeIt->second.size() - 1 : 0;
+            }
+        }
+    };
+
+    basic_ecsView()
+        : m_predicate(makePredicate<Cs...>())
+    {
+    }
+
+    explicit basic_ecsView(ECSWorldT* world)
         : m_world(world)
         , m_predicate(makePredicate<Cs...>())
     {
@@ -41,64 +270,43 @@ public:
     basic_ecsView(const basic_ecsView&) = default;
     basic_ecsView(basic_ecsView&&) = default;
 
+    inline iterator begin() const
+    {
+        if (m_world == nullptr)
+            return iterator();
+        if constexpr (std::is_const_v<ECSWorldT>)
+            return iterator(m_world, &m_predicate, m_world->m_archetypes.cbegin(), m_world->m_archetypes.cend());
+        else
+            return iterator(m_world, &m_predicate, m_world->m_archetypes.begin(), m_world->m_archetypes.end());
+    }
+
+    inline std::default_sentinel_t end() const { return std::default_sentinel; }
+    inline const_iterator cbegin() const { return begin(); }
+    inline std::default_sentinel_t cend() const { return std::default_sentinel; }
+
+    inline reverse_iterator rbegin() const
+    {
+        if (m_world == nullptr)
+            return reverse_iterator();
+        if constexpr (std::is_const_v<ECSWorldT>)
+            return reverse_iterator(m_world, &m_predicate, m_world->m_archetypes.cbegin(), m_world->m_archetypes.cend());
+        else
+            return reverse_iterator(m_world, &m_predicate, m_world->m_archetypes.begin(), m_world->m_archetypes.end());
+    }
+
+    inline std::default_sentinel_t rend() const { return std::default_sentinel; }
+    inline reverse_iterator crbegin() const { return rbegin(); }
+    inline std::default_sentinel_t crend() const { return std::default_sentinel; }
+
     uint32_t count() const
     {
         uint32_t output = 0;
-        for (auto& [archetypeId, archetype] : m_world->m_archetypes) {
+        for (const auto& [archetypeId, archetype] : m_world->m_archetypes)
+        {
             if (std::ranges::includes(archetypeId, m_predicate))
                 output += archetype.size();
         }
         return output;
-    }
-
-    void onFirst(const std::function<void(ECSWorld::EntityID, std::conditional_t<std::is_const_v<ECSWorldT>, const Cs&, Cs&> ...)>& f) const
-    {
-        for (auto& [archetypeId, archetype] : m_world->m_archetypes)
-        {
-            if (std::ranges::includes(archetypeId, m_predicate))
-            {
-                for (uint32_t idx = 0; idx < archetype.size(); idx++)
-                {
-                    f(archetype.getEntityID(idx), *archetype.template getComponentPointer<Cs>(idx) ...);
-                    return;
-                }
-            }
-        }
-    }
-
-    void onFirst(const std::function<void(basic_entity<ECSWorldT>, std::conditional_t<std::is_const_v<ECSWorldT>, const Cs&, Cs&> ...)>& f) const
-    {
-        onFirst([&](typename ECSWorldT::EntityID entityId, std::conditional_t<std::is_const_v<ECSWorldT>, const Cs&, Cs&> ... components){
-            basic_entity<ECSWorldT> entity = {
-                .world = m_world,
-                .entityId = entityId
-            };
-            f(entity, components...);
-        });
-    }
-
-    void onEach(const std::function<void(ECSWorld::EntityID, std::conditional_t<std::is_const_v<ECSWorldT>, const Cs&, Cs&> ...)>& f) const
-    {
-        for (auto& [archetypeId, archetype] : m_world->m_archetypes)
-        {
-            if (std::ranges::includes(archetypeId, m_predicate))
-            {
-                for (uint32_t idx = 0; idx < archetype.size(); idx++)
-                    f(archetype.getEntityID(idx), *archetype.template getComponentPointer<Cs>(idx) ...);
-            }
-        }
-
-    }
-
-    void onEach(const std::function<void(basic_entity<ECSWorldT>, std::conditional_t<std::is_const_v<ECSWorldT>, const Cs&, Cs&> ...)>& f) const
-    {
-        onEach([&](typename ECSWorldT::EntityID entityId, std::conditional_t<std::is_const_v<ECSWorldT>, const Cs&, Cs&> ... components){
-            basic_entity<ECSWorldT> entity = {
-                .world = m_world,
-                .entityId = entityId
-            };
-            f(entity, components...);
-        });
     }
 
     ~basic_ecsView() = default;
@@ -106,6 +314,8 @@ public:
 private:
     ECSWorldT* m_world = nullptr;
     std::set<typename ECSWorldT::ComponentID> m_predicate;
+
+    inline void setWorld(ECSWorldT* world) { m_world = world; }
 
     template<typename T>
     static std::set<typename ECSWorldT::ComponentID> makePredicate()
@@ -123,9 +333,29 @@ private:
     }
 
 public:
-    basic_ecsView& operator = (const basic_ecsView&) = default;
-    basic_ecsView& operator = (basic_ecsView&&) = default;
+    basic_ecsView& operator=(const basic_ecsView&) = default;
+    basic_ecsView& operator=(basic_ecsView&&) = default;
+
+    template<Component... Ts>
+    friend basic_ecsView<ECSWorld, Ts...> operator|(ECSWorld& world, basic_ecsView<ECSWorld, Ts...> view);
+
+    template<Component... Ts>
+    friend basic_ecsView<const ECSWorld, Ts...> operator|(const ECSWorld& world, basic_ecsView<const ECSWorld, Ts...> view);
 };
+
+template<Component... Cs>
+inline basic_ecsView<ECSWorld, Cs...> operator|(ECSWorld& world, basic_ecsView<ECSWorld, Cs...> view)
+{
+    view.setWorld(&world);
+    return view;
+}
+
+template<Component... Cs>
+inline basic_ecsView<const ECSWorld, Cs...> operator|(const ECSWorld& world, basic_ecsView<const ECSWorld, Cs...> view)
+{
+    view.setWorld(&world);
+    return view;
+}
 
 template<Component... Cs>
 using ECSView = basic_ecsView<ECSWorld, Cs...>;
@@ -134,5 +364,19 @@ template<Component... Cs>
 using const_ECSView = basic_ecsView<const ECSWorld, Cs...>;
 
 } // namespace GE
+
+namespace std
+{
+
+template<GE::ECSWorldLike ECSWorldT, GE::Component... Cs>
+struct tuple_size<GE::ecs_view_item<ECSWorldT, Cs...>> : std::integral_constant<std::size_t, sizeof...(Cs)> {};
+
+template<std::size_t I, GE::ECSWorldLike ECSWorldT, GE::Component... Cs>
+struct tuple_element<I, GE::ecs_view_item<ECSWorldT, Cs...>>
+{
+    using type = std::conditional_t<std::is_const_v<ECSWorldT>, const std::tuple_element_t<I, std::tuple<Cs...>>, std::tuple_element_t<I, std::tuple<Cs...>>>;
+};
+
+} // namespace std
 
 #endif // ECSVIEW_HPP

--- a/include/Game-Engine/ECSWorld.hpp
+++ b/include/Game-Engine/ECSWorld.hpp
@@ -18,6 +18,7 @@
 #include <set>
 #include <functional>
 #include <map>
+#include <iterator>
 #include <type_traits>
 
 #define INVALID_ENTITY_ID ULONG_MAX
@@ -39,6 +40,11 @@ public:
     using EntityID = uint64_t;
 
     class Iterator;
+    class ConstIterator;
+    using iterator = Iterator;
+    using const_iterator = ConstIterator;
+    using reverse_iterator = std::reverse_iterator<Iterator>;
+    using const_reverse_iterator = std::reverse_iterator<ConstIterator>;
 
 private:
     template<ECSWorldLike ECSWorldT, Component  ... Cs> requires(sizeof...(Cs) > 0) friend class basic_ecsView;
@@ -81,109 +87,23 @@ public:
     inline uint32_t archetypeCount() { return m_archetypes.size(); }
     uint32_t componentCount();
 
-    Iterator begin() const;
-    Iterator end() const;
+    Iterator begin();
+    Iterator end();
+    const_iterator begin() const;
+    const_iterator end() const;
+    const_iterator cbegin() const;
+    const_iterator cend() const;
+    reverse_iterator rbegin();
+    reverse_iterator rend();
+    const_reverse_iterator rbegin() const;
+    const_reverse_iterator rend() const;
+    const_reverse_iterator crbegin() const;
+    const_reverse_iterator crend() const;
 
     ~ECSWorld() = default;
 
 private:
-    class Archetype
-    {
-    public:
-        Archetype();
-        Archetype(const Archetype&); // copy constructor make no sense inside the same ECSWorld. ment to be used only when copying the ECSWorld
-        Archetype(Archetype&&);
-
-        uint64_t size() const { return m_size; }
-
-        // must be use on empty achetype that are not inserted `ECSWorld::m_archetypes`
-        template<typename T>
-        void addRowType()
-        {
-            // clang-format off
-            m_rows.insert(std::make_pair(componentID<T>(), Row{
-                operator new (componentSize<T>() * m_capacity),
-                componentSize<T>(),
-                componentCopyConstructor<T>(),
-                componentMoveConstructor<T>(),
-                componentDestructor<T>(),
-            }));
-            // clang-format on
-        }
-
-        // must be use on empty achetype that are not inserted `ECSWorld::m_archetypes`
-        template<typename T>
-        void rmvRowType()
-        {
-            {
-                Row& row = m_rows.at(componentID<T>());
-                if (row.buffer != nullptr)
-                {
-                    for (uint64_t i = 0; i < m_size; i++)
-                        row.destructor(static_cast<std::byte*>(row.buffer) + (row.componentSize * i));
-                    operator delete(row.buffer);
-                }
-            }
-            m_rows.erase(componentID<T>());
-        }
-
-        // only duplicate the component infos (no component duplicated)
-        Archetype duplicateRowTypes();
-
-        // only extend the size (and capacity if needed) and return last index
-        uint64_t allocateCollum();
-
-        template<Component T>
-        T* getComponentPointer(uint64_t idx)
-        {
-            Row& row = m_rows.at(componentID<T>());
-            return static_cast<T*>(row.buffer) + idx;
-        }
-
-        template<Component T>
-        const T* getComponentPointer(uint64_t idx) const
-        {
-            const Row& row = m_rows.at(componentID<T>());
-            return static_cast<T*>(row.buffer) + idx;
-        }
-
-        EntityID& getEntityID(uint64_t idx);
-        const EntityID& getEntityID(uint64_t idx) const;
-
-        // destination should be garbage memory
-        // only call the move constructor
-        static void moveComponents(Archetype& arcSrc, uint64_t idxSrc, Archetype& arcDst, uint64_t idxDst);
-
-        // only call the destructor
-        void destructCollum(uint64_t idx);
-
-        // only reduce the size (and capacity if needed)
-        void freeLastCollum();
-
-        ~Archetype();
-
-    private:
-        struct Row
-        {
-            void* buffer = nullptr;
-            const uint64_t componentSize;
-            const CopyConstructor copyConstructor;
-            const MoveConstructor moveConstructor;
-            const Destructor destructor;
-        };
-
-        std::map<ComponentID, Row> m_rows;
-        uint64_t m_size;
-        uint64_t m_capacity;
-
-        void setCapacity(uint64_t);
-        inline void extendCapacity() { setCapacity(m_capacity * 2); }
-        inline void reduceCapacity() { setCapacity(m_capacity / 2 > 0 ? m_capacity / 2 : 1); }
-
-    public:
-        Archetype& operator=(const Archetype&);
-        Archetype& operator=(Archetype&&);
-    };
+    #include "Game-Engine/detail/ECSWorldArchetype.inl"
 
     struct EntityData
     {
@@ -211,63 +131,7 @@ public:
     // friend void from_json(const nlohmann::json&, ECSWorld&);
 
 public:
-    class Iterator
-    {
-    private:
-        friend class ECSWorld;
-
-    public:
-        Iterator() = default;
-        Iterator(const Iterator& cp) = default;
-        Iterator(Iterator&& mv) = default;
-
-        ~Iterator() = default;
-
-    private:
-        Iterator(const ECSWorld& world, EntityID id) : m_world(&world), m_id(id) {}
-
-        const ECSWorld* m_world = nullptr;
-        EntityID m_id = INVALID_ENTITY_ID;
-
-    public:
-        Iterator& operator=(const Iterator& cp) = default;
-        Iterator& operator=(Iterator&& mv) = default;
-
-        inline EntityID operator*() const { return m_id; }
-
-        inline Iterator& operator++()
-        {
-            do
-            {
-                ++m_id;
-            } while (m_world->m_availableEntityIDs.contains(m_id));
-            return *this;
-        }
-        inline Iterator operator++(int)
-        {
-            Iterator temp(*this);
-            ++(*this);
-            return temp;
-        }
-
-        inline Iterator& operator--()
-        {
-            do
-            {
-                --m_id;
-            } while (m_world->m_availableEntityIDs.contains(m_id));
-            return *this;
-        }
-        inline Iterator operator--(int)
-        {
-            Iterator temp(*this);
-            --(*this);
-            return temp;
-        }
-
-        inline bool operator==(const Iterator& rhs) const { return m_world == rhs.m_world && m_id == rhs.m_id; }
-        inline bool operator!=(const Iterator& rhs) const { return !(*this == rhs); }
-    };
+    #include "Game-Engine/detail/ECSWorldIterator.inl"
 };
 
 template<Component T, typename... Args>

--- a/include/Game-Engine/detail/ECSWorldArchetype.inl
+++ b/include/Game-Engine/detail/ECSWorldArchetype.inl
@@ -1,0 +1,153 @@
+class Archetype
+{
+public:
+    class Iterator
+    {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using iterator_concept = std::forward_iterator_tag;
+        using value_type = EntityID;
+        using difference_type = std::ptrdiff_t;
+
+        Iterator() = default;
+        Iterator(Archetype* archetype, uint64_t idx) : m_archetype(archetype), m_idx(idx) {}
+
+        inline EntityID operator*() const { return m_archetype->getEntityID(m_idx); }
+        inline Iterator& operator++() { ++m_idx; return *this; }
+        inline Iterator operator++(int) { Iterator temp(*this); ++(*this); return temp; }
+        inline bool operator==(const Iterator& rhs) const { return m_archetype == rhs.m_archetype && m_idx == rhs.m_idx; }
+        inline bool operator!=(const Iterator& rhs) const { return !(*this == rhs); }
+        inline uint64_t index() const { return m_idx; }
+
+    private:
+        Archetype* m_archetype = nullptr;
+        uint64_t m_idx = 0;
+    };
+
+    class ConstIterator
+    {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using iterator_concept = std::forward_iterator_tag;
+        using value_type = EntityID;
+        using difference_type = std::ptrdiff_t;
+
+        ConstIterator() = default;
+        ConstIterator(const Archetype* archetype, uint64_t idx) : m_archetype(archetype), m_idx(idx) {}
+
+        inline EntityID operator*() const { return m_archetype->getEntityID(m_idx); }
+        inline ConstIterator& operator++() { ++m_idx; return *this; }
+        inline ConstIterator operator++(int) { ConstIterator temp(*this); ++(*this); return temp; }
+        inline bool operator==(const ConstIterator& rhs) const { return m_archetype == rhs.m_archetype && m_idx == rhs.m_idx; }
+        inline bool operator!=(const ConstIterator& rhs) const { return !(*this == rhs); }
+        inline uint64_t index() const { return m_idx; }
+
+    private:
+        const Archetype* m_archetype = nullptr;
+        uint64_t m_idx = 0;
+    };
+
+    using iterator = Iterator;
+    using const_iterator = ConstIterator;
+
+    Archetype();
+    Archetype(const Archetype&); // copy constructor make no sense inside the same ECSWorld. ment to be used only when copying the ECSWorld
+    Archetype(Archetype&&);
+
+    uint64_t size() const { return m_size; }
+
+    inline iterator begin() { return iterator(this, 0); }
+    inline iterator end() { return iterator(this, m_size); }
+    inline const_iterator begin() const { return const_iterator(this, 0); }
+    inline const_iterator end() const { return const_iterator(this, m_size); }
+    inline const_iterator cbegin() const { return const_iterator(this, 0); }
+    inline const_iterator cend() const { return const_iterator(this, m_size); }
+
+    // must be use on empty achetype that are not inserted `ECSWorld::m_archetypes`
+    template<typename T>
+    void addRowType()
+    {
+        // clang-format off
+        m_rows.insert(std::make_pair(componentID<T>(), Row{
+            operator new (componentSize<T>() * m_capacity),
+            componentSize<T>(),
+            componentCopyConstructor<T>(),
+            componentMoveConstructor<T>(),
+            componentDestructor<T>(),
+        }));
+        // clang-format on
+    }
+
+    // must be use on empty achetype that are not inserted `ECSWorld::m_archetypes`
+    template<typename T>
+    void rmvRowType()
+    {
+        {
+            Row& row = m_rows.at(componentID<T>());
+            if (row.buffer != nullptr)
+            {
+                for (uint64_t i = 0; i < m_size; i++)
+                    row.destructor(static_cast<std::byte*>(row.buffer) + (row.componentSize * i));
+                operator delete(row.buffer);
+            }
+        }
+        m_rows.erase(componentID<T>());
+    }
+
+    // only duplicate the component infos (no component duplicated)
+    Archetype duplicateRowTypes();
+
+    // only extend the size (and capacity if needed) and return last index
+    uint64_t allocateCollum();
+
+    template<Component T>
+    T* getComponentPointer(uint64_t idx)
+    {
+        Row& row = m_rows.at(componentID<T>());
+        return static_cast<T*>(row.buffer) + idx;
+    }
+
+    template<Component T>
+    const T* getComponentPointer(uint64_t idx) const
+    {
+        const Row& row = m_rows.at(componentID<T>());
+        return static_cast<T*>(row.buffer) + idx;
+    }
+
+    EntityID& getEntityID(uint64_t idx);
+    const EntityID& getEntityID(uint64_t idx) const;
+
+    // destination should be garbage memory
+    // only call the move constructor
+    static void moveComponents(Archetype& arcSrc, uint64_t idxSrc, Archetype& arcDst, uint64_t idxDst);
+
+    // only call the destructor
+    void destructCollum(uint64_t idx);
+
+    // only reduce the size (and capacity if needed)
+    void freeLastCollum();
+
+    ~Archetype();
+
+private:
+    struct Row
+    {
+        void* buffer = nullptr;
+        const uint64_t componentSize;
+        const CopyConstructor copyConstructor;
+        const MoveConstructor moveConstructor;
+        const Destructor destructor;
+    };
+
+    std::map<ComponentID, Row> m_rows;
+    uint64_t m_size;
+    uint64_t m_capacity;
+
+    void setCapacity(uint64_t);
+    inline void extendCapacity() { setCapacity(m_capacity * 2); }
+    inline void reduceCapacity() { setCapacity(m_capacity / 2 > 0 ? m_capacity / 2 : 1); }
+
+public:
+    Archetype& operator=(const Archetype&);
+    Archetype& operator=(Archetype&&);
+};

--- a/include/Game-Engine/detail/ECSWorldIterator.inl
+++ b/include/Game-Engine/detail/ECSWorldIterator.inl
@@ -1,0 +1,128 @@
+class Iterator
+{
+private:
+    friend class ECSWorld;
+
+public:
+    using iterator_category = std::bidirectional_iterator_tag;
+    using iterator_concept = std::bidirectional_iterator_tag;
+    using value_type = EntityID;
+    using difference_type = std::ptrdiff_t;
+    using reference = EntityID;
+
+    Iterator() = default;
+    Iterator(const Iterator& cp) = default;
+    Iterator(Iterator&& mv) = default;
+
+    ~Iterator() = default;
+
+private:
+    Iterator(const ECSWorld& world, EntityID id) : m_world(&world), m_id(id) {}
+
+    const ECSWorld* m_world = nullptr;
+    EntityID m_id = INVALID_ENTITY_ID;
+
+public:
+    Iterator& operator=(const Iterator& cp) = default;
+    Iterator& operator=(Iterator&& mv) = default;
+
+    inline EntityID operator*() const { return m_id; }
+
+    inline Iterator& operator++()
+    {
+        do
+        {
+            ++m_id;
+        } while (m_world->m_availableEntityIDs.contains(m_id));
+        return *this;
+    }
+    inline Iterator operator++(int)
+    {
+        Iterator temp(*this);
+        ++(*this);
+        return temp;
+    }
+
+    inline Iterator& operator--()
+    {
+        do
+        {
+            --m_id;
+        } while (m_world->m_availableEntityIDs.contains(m_id));
+        return *this;
+    }
+    inline Iterator operator--(int)
+    {
+        Iterator temp(*this);
+        --(*this);
+        return temp;
+    }
+
+    inline bool operator==(const Iterator& rhs) const { return m_world == rhs.m_world && m_id == rhs.m_id; }
+    inline bool operator!=(const Iterator& rhs) const { return !(*this == rhs); }
+};
+
+class ConstIterator
+{
+private:
+    friend class ECSWorld;
+
+public:
+    using iterator_category = std::bidirectional_iterator_tag;
+    using iterator_concept = std::bidirectional_iterator_tag;
+    using value_type = EntityID;
+    using difference_type = std::ptrdiff_t;
+    using reference = EntityID;
+
+    ConstIterator() = default;
+    ConstIterator(const ConstIterator& cp) = default;
+    ConstIterator(ConstIterator&& mv) = default;
+    ConstIterator(const Iterator& it) : m_world(it.m_world), m_id(it.m_id) {}
+
+    ~ConstIterator() = default;
+
+private:
+    ConstIterator(const ECSWorld& world, EntityID id) : m_world(&world), m_id(id) {}
+
+    const ECSWorld* m_world = nullptr;
+    EntityID m_id = INVALID_ENTITY_ID;
+
+public:
+    ConstIterator& operator=(const ConstIterator& cp) = default;
+    ConstIterator& operator=(ConstIterator&& mv) = default;
+
+    inline EntityID operator*() const { return m_id; }
+
+    inline ConstIterator& operator++()
+    {
+        do
+        {
+            ++m_id;
+        } while (m_world->m_availableEntityIDs.contains(m_id));
+        return *this;
+    }
+    inline ConstIterator operator++(int)
+    {
+        ConstIterator temp(*this);
+        ++(*this);
+        return temp;
+    }
+
+    inline ConstIterator& operator--()
+    {
+        do
+        {
+            --m_id;
+        } while (m_world->m_availableEntityIDs.contains(m_id));
+        return *this;
+    }
+    inline ConstIterator operator--(int)
+    {
+        ConstIterator temp(*this);
+        --(*this);
+        return temp;
+    }
+
+    inline bool operator==(const ConstIterator& rhs) const { return m_world == rhs.m_world && m_id == rhs.m_id; }
+    inline bool operator!=(const ConstIterator& rhs) const { return !(*this == rhs); }
+};

--- a/src/ECSWorld.cpp
+++ b/src/ECSWorld.cpp
@@ -90,7 +90,20 @@ uint32_t ECSWorld::componentCount()
     return count;
 }
 
-ECSWorld::Iterator ECSWorld::begin() const
+ECSWorld::const_iterator ECSWorld::begin() const
+{
+    EntityID id = 0;
+    while (m_availableEntityIDs.contains(id))
+        id++;
+    return const_iterator(*this, id);
+}
+
+ECSWorld::const_iterator ECSWorld::end() const
+{
+    return const_iterator(*this, m_entityDatas.size());
+}
+
+ECSWorld::Iterator ECSWorld::begin()
 {
     EntityID id = 0;
     while (m_availableEntityIDs.contains(id))
@@ -98,9 +111,49 @@ ECSWorld::Iterator ECSWorld::begin() const
     return Iterator(*this, id);
 }
 
-ECSWorld::Iterator ECSWorld::end() const
+ECSWorld::Iterator ECSWorld::end()
 {
     return Iterator(*this, m_entityDatas.size());
+}
+
+ECSWorld::const_iterator ECSWorld::cbegin() const
+{
+    return begin();
+}
+
+ECSWorld::const_iterator ECSWorld::cend() const
+{
+    return end();
+}
+
+ECSWorld::reverse_iterator ECSWorld::rbegin()
+{
+    return reverse_iterator(end());
+}
+
+ECSWorld::reverse_iterator ECSWorld::rend()
+{
+    return reverse_iterator(begin());
+}
+
+ECSWorld::const_reverse_iterator ECSWorld::rbegin() const
+{
+    return const_reverse_iterator(end());
+}
+
+ECSWorld::const_reverse_iterator ECSWorld::rend() const
+{
+    return const_reverse_iterator(begin());
+}
+
+ECSWorld::const_reverse_iterator ECSWorld::crbegin() const
+{
+    return const_reverse_iterator(cend());
+}
+
+ECSWorld::const_reverse_iterator ECSWorld::crend() const
+{
+    return const_reverse_iterator(cbegin());
 }
 
 ECSWorld::ComponentID ECSWorld::nextComponentID()

--- a/src/FramePassBuilder.cpp
+++ b/src/FramePassBuilder.cpp
@@ -63,8 +63,10 @@ FramePass FlatGeometryPassBuilder::build() const
 
         std::vector<shader::DirectionalLight> directionalLights;
         std::vector<shader::PointLight> pointLights;
-        const_ECSView<TransformComponent, LightComponent>(&scene->ecsWorld()).onEach([&](const_Entity entity, const TransformComponent&, const LightComponent& light)
+        for (auto row : scene->ecsWorld() | const_ECSView<TransformComponent, LightComponent>())
         {
+            const_Entity entity = { .world = &scene->ecsWorld(), .entityId = static_cast<ECSWorld::EntityID>(row) };
+            const LightComponent& light = GE::get<1>(row);
             switch (light.type)
             {
             case LightComponent::Type::directional:
@@ -81,7 +83,7 @@ FramePass FlatGeometryPassBuilder::build() const
                 });
                 break;
             }
-        });
+        }
 
         frameData.directionalLightCount = directionalLights.size();
         frameData.pointLightCount = pointLights.size();
@@ -111,8 +113,10 @@ FramePass FlatGeometryPassBuilder::build() const
         ctx.commandBuffer.setParameterBlock(frameDataPBlock, 0);
         ctx.commandBuffer.setParameterBlock(materialPBlock, 1);
 
-        const_ECSView<TransformComponent, MeshComponent>(&scene->ecsWorld()).onEach([&](const_Entity entity, const TransformComponent&, const MeshComponent meshId)
+        for (auto row : scene->ecsWorld() | const_ECSView<TransformComponent, MeshComponent>())
         {
+            const_Entity entity = { .world = &scene->ecsWorld(), .entityId = static_cast<ECSWorld::EntityID>(row) };
+            const MeshComponent meshId = GE::get<1>(row);
             std::shared_future<const std::shared_ptr<Mesh>&> meshFuture = scene->assetManagerView().loadAsset<Mesh>(meshId);
             if (meshFuture.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
             {
@@ -132,7 +136,7 @@ FramePass FlatGeometryPassBuilder::build() const
                 for (auto& submesh : mesh->subMeshes)
                     drawSubmesh(submesh, entity.worldTransform());
             }
-        });
+        }
     };
 
     return framePass;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -11,22 +11,24 @@
 #include "Game-Engine/AssetManager.hpp"
 
 #include <cassert>
-#include <ranges>
 #include <utility>
 
 namespace GE
 {
 
 Game::Game(AssetManager* assetManager, const Descriptor& desc)
-    : m_scenes(std::from_range, desc.scenes | std::views::transform([&](const auto& sceneDesc){ return std::make_pair(sceneDesc.first, Scene(assetManager, sceneDesc.second)); }))
-    , m_activeScene(&m_scenes.at(desc.activeScene))
+    : m_activeScene(nullptr)
     , m_inputContext(desc.inputContext)
 {
+    for (const auto& [name, sceneDesc] : desc.scenes)
+        m_scenes.insert(std::make_pair(name, Scene(assetManager, sceneDesc)));
+
+    m_activeScene = &m_scenes.at(desc.activeScene);
 }
 
 void Game::switchActiveScene(const std::string& name)
 {
-    Scene* newActiveScene = &m_scenes.at(name);
+    m_activeScene = &m_scenes.at(name);
     /*
     if (newActiveScene->isLoaded() == false) {
         newActiveScene->load();

--- a/tests/ECS_testCases.cpp
+++ b/tests/ECS_testCases.cpp
@@ -13,6 +13,8 @@
 #include "Game-Engine/ECSView.hpp"
 
 #include <set>
+#include <vector>
+#include <ranges>
 
 namespace GE_tests
 {
@@ -246,6 +248,44 @@ TEST(ECSTest, multipleEntityTwoComponent)
     EXPECT_EQ(world.componentCount(), 6);
 }
 
+TEST(ECSTest, worldRange)
+{
+    GE::ECSWorld world;
+
+    EntityID entity1 = world.newEntityID();
+    EntityID entity2 = world.newEntityID();
+    EntityID entity3 = world.newEntityID();
+
+    world.deleteEntityID(entity2);
+
+    EXPECT_EQ(std::ranges::distance(world), 2);
+    EXPECT_EQ(std::ranges::distance(world.cbegin(), world.cend()), 2);
+
+    std::vector<EntityID> forward;
+    for (EntityID id : world)
+        forward.push_back(id);
+
+    std::vector<EntityID> reverse;
+    for (auto it = world.rbegin(); it != world.rend(); ++it)
+        reverse.push_back(*it);
+
+    std::vector<EntityID> constReverse;
+    const GE::ECSWorld& constWorld = world;
+    for (auto it = constWorld.crbegin(); it != constWorld.crend(); ++it)
+        constReverse.push_back(*it);
+
+    ASSERT_EQ(forward.size(), 2);
+    ASSERT_EQ(reverse.size(), 2);
+    ASSERT_EQ(constReverse.size(), 2);
+
+    EXPECT_EQ(forward[0], entity1);
+    EXPECT_EQ(forward[1], entity3);
+    EXPECT_EQ(reverse[0], entity3);
+    EXPECT_EQ(reverse[1], entity1);
+    EXPECT_EQ(constReverse[0], entity3);
+    EXPECT_EQ(constReverse[1], entity1);
+}
+
 TYPED_TEST(ECSTest, componentEdit)
 {
     GE::ECSWorld world;
@@ -295,55 +335,91 @@ TEST(ECSTest, view)
     world.emplace<Component2>(entity3, 3);
 
     {
-        GE::ECSView<Component1> view(&world);
+        GE::ECSView<Component1> view = world | GE::ECSView<Component1>();
         EXPECT_EQ(view.count(), 2);
 
         EXPECT_NO_THROW({
             std::set<EntityID> entities;
             std::set<int> values;
+            std::vector<EntityID> idsForward;
+            std::vector<EntityID> idsReverse;
 
-            view.onEach([&](EntityID entityId, Component1& comp){
-                entities.insert(entityId);
-                values.insert(comp.val());
-            });
+            for (auto it = view.cbegin(); it != view.cend(); ++it)
+            {
+                entities.insert(static_cast<EntityID>(*it));
+                values.insert(GE::get<0>(*it).val());
+                idsForward.push_back(static_cast<EntityID>(*it));
+            }
+
+            for (auto it = view.rbegin(); it != view.rend(); ++it)
+            {
+                idsReverse.push_back(static_cast<EntityID>(*it));
+            }
 
             EXPECT_EQ(entities.size(), 2);
             EXPECT_EQ(values.size(), 2);
+            EXPECT_EQ(idsForward.size(), 2);
+            EXPECT_EQ(idsReverse.size(), 2);
+            EXPECT_EQ(idsForward[0], entity1);
+            EXPECT_EQ(idsForward[1], entity3);
+            EXPECT_EQ(idsReverse[0], entity3);
+            EXPECT_EQ(idsReverse[1], entity1);
         });
     }
     {
-        GE::ECSView<Component2> view(&world);
+        GE::ECSView<Component2> view = world | GE::ECSView<Component2>();
         EXPECT_EQ(view.count(), 2);
 
         EXPECT_NO_THROW({
             std::set<EntityID> entities;
             std::set<int> values;
+            std::vector<EntityID> idsForward;
+            std::vector<EntityID> idsReverse;
 
-            view.onEach([&](EntityID entityId, Component2& comp){
-                entities.insert(entityId);
-                values.insert(comp.val());
-            });
+            for (auto it = view.cbegin(); it != view.cend(); ++it)
+            {
+                entities.insert(static_cast<EntityID>(*it));
+                values.insert(GE::get<0>(*it).val());
+                idsForward.push_back(static_cast<EntityID>(*it));
+            }
+
+            for (auto it = view.crbegin(); it != view.crend(); ++it)
+            {
+                idsReverse.push_back(static_cast<EntityID>(*it));
+            }
 
             EXPECT_EQ(entities.size(), 2);
             EXPECT_EQ(values.size(), 2);
+            EXPECT_EQ(idsForward.size(), 2);
+            EXPECT_EQ(idsReverse.size(), 2);
+            EXPECT_EQ(idsForward[0], entity1);
+            EXPECT_EQ(idsForward[1], entity3);
+            EXPECT_EQ(idsReverse[0], entity3);
+            EXPECT_EQ(idsReverse[1], entity1);
         });
     }
     {
-        GE::ECSView<Component1, Component2> view(&world);
+        GE::ECSView<Component1, Component2> view = world | GE::ECSView<Component1, Component2>();
         EXPECT_EQ(view.count(), 1);
 
         EXPECT_NO_THROW({
-            std::set<EntityID> entities;
+            std::set<EntityID> entityIds;
             std::set<int> values1;
             std::set<int> values2;
 
-            view.onEach([&](EntityID entityId, Component1& comp1, Component2& comp2){
-                entities.insert(entityId);
-                values1.insert(comp1.val());
-                values2.insert(comp2.val());
-            });
+            for (EntityID id : view)
+                entityIds.insert(id);
 
-            EXPECT_EQ(entities.size(), 1);
+            for (EntityID id : world | GE::ECSView<Component1, Component2>())
+                entityIds.insert(id);
+
+            for (auto [component1, component2] : world | GE::ECSView<Component1, Component2>())
+            {
+                values1.insert(component1.val());
+                values2.insert(component2.val());
+            }
+
+            EXPECT_EQ(entityIds.size(), 1);
             EXPECT_EQ(values1.size(), 1);
             EXPECT_EQ(values2.size(), 1);
         });
@@ -364,56 +440,80 @@ TEST(ECSTest, constView)
     world.emplace<Component1>(entity3, 3);
     world.emplace<Component2>(entity3, 3);
 
+    const GE::ECSWorld& constWorld = world;
+
     {
-        GE::const_ECSView<Component1> view(&world);
+        GE::const_ECSView<Component1> view = constWorld | GE::const_ECSView<Component1>();
+        EXPECT_EQ(view.count(), 2);
+
+        EXPECT_NO_THROW({
+            std::set<EntityID> entities;
+            std::set<int> values;
+            std::vector<EntityID> idsForward;
+            std::vector<EntityID> idsReverse;
+
+            for (auto it = view.cbegin(); it != view.cend(); ++it)
+            {
+                entities.insert(static_cast<EntityID>(*it));
+                values.insert(GE::get<0>(*it).val());
+                idsForward.push_back(static_cast<EntityID>(*it));
+            }
+
+            for (auto it = view.crbegin(); it != view.crend(); ++it)
+            {
+                idsReverse.push_back(static_cast<EntityID>(*it));
+            }
+
+            EXPECT_EQ(entities.size(), 2);
+            EXPECT_EQ(values.size(), 2);
+            EXPECT_EQ(idsForward.size(), 2);
+            EXPECT_EQ(idsReverse.size(), 2);
+            EXPECT_EQ(idsForward[0], entity1);
+            EXPECT_EQ(idsForward[1], entity3);
+            EXPECT_EQ(idsReverse[0], entity3);
+            EXPECT_EQ(idsReverse[1], entity1);
+        });
+    }
+    {
+        GE::const_ECSView<Component2> view = constWorld | GE::const_ECSView<Component2>();
         EXPECT_EQ(view.count(), 2);
 
         EXPECT_NO_THROW({
             std::set<EntityID> entities;
             std::set<int> values;
 
-            view.onEach([&](EntityID entityId, const Component1& comp){
-                entities.insert(entityId);
-                values.insert(comp.val());
-            });
+            for (auto row : view)
+            {
+                entities.insert(static_cast<EntityID>(row));
+                values.insert(GE::get<0>(row).val());
+            }
 
             EXPECT_EQ(entities.size(), 2);
             EXPECT_EQ(values.size(), 2);
         });
     }
     {
-        GE::const_ECSView<Component2> view(&world);
-        EXPECT_EQ(view.count(), 2);
-
-        EXPECT_NO_THROW({
-            std::set<EntityID> entities;
-            std::set<int> values;
-
-            view.onEach([&](EntityID entityId, const Component2& comp){
-                entities.insert(entityId);
-                values.insert(comp.val());
-            });
-
-            EXPECT_EQ(entities.size(), 2);
-            EXPECT_EQ(values.size(), 2);
-        });
-    }
-    {
-        GE::const_ECSView<Component1, Component2> view(&world);
+        GE::const_ECSView<Component1, Component2> view = constWorld | GE::const_ECSView<Component1, Component2>();
         EXPECT_EQ(view.count(), 1);
 
         EXPECT_NO_THROW({
-            std::set<EntityID> entities;
+            std::set<EntityID> entityIds;
             std::set<int> values1;
             std::set<int> values2;
 
-            view.onEach([&](EntityID entityId, const Component1& comp1, const Component2& comp2){
-                entities.insert(entityId);
-                values1.insert(comp1.val());
-                values2.insert(comp2.val());
-            });
+            for (EntityID id : view)
+                entityIds.insert(id);
 
-            EXPECT_EQ(entities.size(), 1);
+            for (EntityID id : constWorld | GE::const_ECSView<Component1, Component2>())
+                entityIds.insert(id);
+
+            for (auto [component1, component2] : constWorld | GE::const_ECSView<Component1, Component2>())
+            {
+                values1.insert(component1.val());
+                values2.insert(component2.val());
+            }
+
+            EXPECT_EQ(entityIds.size(), 1);
             EXPECT_EQ(values1.size(), 1);
             EXPECT_EQ(values2.size(), 1);
         });


### PR DESCRIPTION
### Motivation

- Modernize the ECS iteration API to support range-based loops and integrate with the C++ ranges/View model so callers can iterate views with `for`-ranges and structured bindings. 
- Improve const-correctness and iterator ergonomics for `ECSWorld` and `ECSView`, and separate large implementation details into dedicated inline implementation files to simplify the header.

### Description

- Introduced `ecs_view_item` and made `basic_ecsView` a `std::ranges::view_interface` with concrete `iterator` and `reverse_iterator` implementations, added `operator|` overloads to bind a view to an `ECSWorld`, and provided `get<>`/`tuple_size`/`tuple_element` customizations to allow tuple-like access to components. 
- Refactored `ECSWorld` to expose proper `begin`/`end` overloads (const and non-const), const iterators, and reverse iterators, and moved the previous nested `Archetype` and `Iterator` implementations into `include/Game-Engine/detail/ECSWorldArchetype.inl` and `include/Game-Engine/detail/ECSWorldIterator.inl`. 
- Updated call sites to use the new range-based APIs and `GE::get<>` access: `SceneGraphPanel`, `FramePassBuilder`, `Game`, and `Project::gameDescriptor` were adjusted to iterate views with `for` and to build scene maps without using `std::views` helper hacks. 
- Tests were updated to exercise the new iteration model (added `worldRange` test and adapted view tests to use `cbegin`/`crbegin`, range-for, reverse iteration and structured access), and header includes adjusted accordingly.

### Testing

- Ran the ECS unit tests in `tests/ECS_testCases.cpp` (GoogleTest suite) to validate iteration behavior and view semantics, and all tests passed. 
- Built and linked the engine to ensure the updated headers and inlined implementation files compile correctly, and the build succeeded. 
- Exercised range-based iteration scenarios (forward, reverse, const) via updated tests and verified expected entity ordering and component values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e18af5aaa483218ef43d5b066f577e)