### PR TITLE
Refactor ECS component handling to use a single component typelist

### DIFF
--- a/editor/UI/EntityInspectorPanel.cpp
+++ b/editor/UI/EntityInspectorPanel.cpp
@@ -13,6 +13,7 @@
 #include <Game-Engine/ECSWorld.hpp>
 #include <Game-Engine/Entity.hpp>
 #include <Game-Engine/Script.hpp>
+#include <Game-Engine/TypeList.hpp>
 
 #include <imgui.h>
 
@@ -26,6 +27,35 @@
 
 namespace GE_Editor
 {
+
+using EditableEntityComponents = GE::TypeList<GE::TransformComponent, GE::CameraComponent, GE::LightComponent, GE::ScriptComponent>;
+
+template<typename T>
+struct EditableEntityComponentTraits;
+
+template<>
+struct EditableEntityComponentTraits<GE::TransformComponent>
+{
+    static constexpr const char* label = "Transform component";
+};
+
+template<>
+struct EditableEntityComponentTraits<GE::CameraComponent>
+{
+    static constexpr const char* label = "Camera component";
+};
+
+template<>
+struct EditableEntityComponentTraits<GE::LightComponent>
+{
+    static constexpr const char* label = "Light component";
+};
+
+template<>
+struct EditableEntityComponentTraits<GE::ScriptComponent>
+{
+    static constexpr const char* label = "Script component";
+};
 
 template<>
 void EntityInspectorPanel::componentEditWidget<GE::NameComponent>()
@@ -169,14 +199,10 @@ void EntityInspectorPanel::render()
         else
         {
             componentEditWidget<GE::NameComponent>();
-            if (m_entity.has<GE::TransformComponent>() && componentEditHeader<GE::TransformComponent>("Transform component"))
-                componentEditWidget<GE::TransformComponent>();
-            if (m_entity.has<GE::CameraComponent>() && componentEditHeader<GE::CameraComponent>("Camera component"))
-                componentEditWidget<GE::CameraComponent>();
-            if (m_entity.has<GE::LightComponent>() && componentEditHeader<GE::LightComponent>("Light component"))
-                componentEditWidget<GE::LightComponent>();
-            if (m_entity.has<GE::ScriptComponent>() && componentEditHeader<GE::ScriptComponent>("Script component"))
-                componentEditWidget<GE::ScriptComponent>();
+            GE::forEachType<EditableEntityComponents>([&]<typename ComponentT>() {
+                if (m_entity.has<ComponentT>() && componentEditHeader<ComponentT>(EditableEntityComponentTraits<ComponentT>::label))
+                    componentEditWidget<ComponentT>();
+            });
 
             ImGui::Spacing();
             ImGui::Separator();
@@ -210,17 +236,10 @@ void EntityInspectorPanel::addComponentPopUp()
 {
     if (ImGui::BeginPopup("add_component_popup"))
     {
-        if (m_entity.has<GE::TransformComponent>() == false && ImGui::Selectable("Transform component"))
-            m_entity.emplace<GE::TransformComponent>();
-
-        if (m_entity.has<GE::CameraComponent>() == false && ImGui::Selectable("Camera component"))
-            m_entity.emplace<GE::CameraComponent>();
-
-        if (m_entity.has<GE::LightComponent>() == false && ImGui::Selectable("Light component"))
-            m_entity.emplace<GE::LightComponent>();
-
-        if (m_entity.has<GE::ScriptComponent>() == false && ImGui::Selectable("Script component"))
-            m_entity.emplace<GE::ScriptComponent>();
+        GE::forEachType<EditableEntityComponents>([&]<typename ComponentT>() {
+            if (m_entity.has<ComponentT>() == false && ImGui::Selectable(EditableEntityComponentTraits<ComponentT>::label))
+                m_entity.emplace<ComponentT>();
+        });
 
         ImGui::EndPopup();
     }

--- a/include/Game-Engine/AssetManager.hpp
+++ b/include/Game-Engine/AssetManager.hpp
@@ -76,7 +76,7 @@ struct AssetPathYamlTraits<AssetPath<gfx::Texture>>
 template<typename AssetT>
 using AssetPathType = AssetPath<AssetT>;
 
-using AssetPathTypes = TypeListMap_t<ManagableAssetTypes, AssetPathType>;
+using AssetPathTypes = ManagableAssetTypes::wrapped<AssetPathType>;
 using VAssetPath = AssetPathTypes::into<std::variant>;
 
 template<typename T>
@@ -164,7 +164,7 @@ private:
     template<typename AssetT>
     using AssetHandleType = AssetHandle<AssetT>;
 
-    using AssetHandleTypes = TypeListMap_t<ManagableAssetTypes, AssetHandleType>;
+    using AssetHandleTypes = ManagableAssetTypes::wrapped<AssetHandleType>;
     using VAssetHandle = AssetHandleTypes::into<std::variant>;
 
     template<ManagableAsset T>

--- a/include/Game-Engine/AssetManager.hpp
+++ b/include/Game-Engine/AssetManager.hpp
@@ -64,13 +64,13 @@ struct AssetPathYamlTraits;
 template<>
 struct AssetPathYamlTraits<AssetPath<Mesh>>
 {
-    static constexpr std::string_view assetTypeStr = "Mesh";
+    static constexpr std::string_view name = "Mesh";
 };
 
 template<>
 struct AssetPathYamlTraits<AssetPath<gfx::Texture>>
 {
-    static constexpr std::string_view assetTypeStr = "Texture";
+    static constexpr std::string_view name = "Texture";
 };
 
 template<typename AssetT>
@@ -244,7 +244,7 @@ struct convert<GE::VAssetPath>
         std::visit([&](auto& assetPath)
         {
             using AssetPathT = std::remove_cvref_t<decltype(assetPath)>;
-            node["type"] = std::string(GE::AssetPathYamlTraits<AssetPathT>::assetTypeStr);
+            node["type"] = std::string(GE::AssetPathYamlTraits<AssetPathT>::name);
             node["path"] = std::string(assetPath.path);
         },
         rhs);
@@ -261,7 +261,7 @@ struct convert<GE::VAssetPath>
         bool isDecoded = false;
 
         GE::forEachType<GE::AssetPathTypes>([&]<typename AssetPathT>() {
-            if (isDecoded || type != GE::AssetPathYamlTraits<AssetPathT>::assetTypeStr)
+            if (isDecoded || type != GE::AssetPathYamlTraits<AssetPathT>::name)
                 return;
 
             rhs = AssetPathT(path);

--- a/include/Game-Engine/AssetManager.hpp
+++ b/include/Game-Engine/AssetManager.hpp
@@ -12,6 +12,7 @@
 
 #include "Game-Engine/Export.hpp"
 #include "Game-Engine/Mesh.hpp"
+#include "Game-Engine/TypeList.hpp"
 
 #include <Graphics/Device.hpp>
 #include <Graphics/Texture.hpp>
@@ -39,8 +40,10 @@
 namespace GE
 {
 
+using ManagableAssetTypes = TypeList<Mesh, gfx::Texture>;
+
 template<typename T>
-concept ManagableAsset = std::is_same_v<std::remove_cvref_t<T>, Mesh> || std::is_same_v<std::remove_cvref_t<T>, gfx::Texture>;
+concept ManagableAsset = IsTypeInList<std::remove_cvref_t<T>, ManagableAssetTypes>;
 
 template<ManagableAsset T>
 struct AssetPath
@@ -70,7 +73,11 @@ struct AssetPathYamlTraits<AssetPath<gfx::Texture>>
     static constexpr std::string_view assetTypeStr = "Texture";
 };
 
-using VAssetPath = std::variant<AssetPath<Mesh>, AssetPath<gfx::Texture>>;
+template<typename AssetT>
+using AssetPathType = AssetPath<AssetT>;
+
+using AssetPathTypes = TypeListMap_t<ManagableAssetTypes, AssetPathType>;
+using VAssetPath = AssetPathTypes::into<std::variant>;
 
 template<typename T>
 concept VAssetPathRange = std::ranges::range<T> && std::is_same_v<std::ranges::range_value_t<T>, VAssetPath>;
@@ -154,7 +161,11 @@ private:
         std::shared_ptr<T> asset;
     };
 
-    using VAssetHandle = std::variant<AssetHandle<Mesh>, AssetHandle<gfx::Texture>>;
+    template<typename AssetT>
+    using AssetHandleType = AssetHandle<AssetT>;
+
+    using AssetHandleTypes = TypeListMap_t<ManagableAssetTypes, AssetHandleType>;
+    using VAssetHandle = AssetHandleTypes::into<std::variant>;
 
     template<ManagableAsset T>
     const std::shared_future<const std::shared_ptr<T>&>& loadAssetHandle(VAssetHandle& vHandle) {
@@ -244,14 +255,20 @@ struct convert<GE::VAssetPath>
     {
         if (!node.IsMap() || !node["type"] || !node["path"])
             return false;
+
         const std::string type = node["type"].as<std::string>();
-        if (type == "Mesh")
-            rhs = GE::AssetPath<GE::Mesh>(std::filesystem::path(node["path"].as<std::string>()));
-        else if (type == "Texture")
-            rhs = GE::AssetPath<gfx::Texture>(std::filesystem::path(node["path"].as<std::string>()));
-        else
-            return false;
-        return true;
+        const std::filesystem::path path = node["path"].as<std::string>();
+        bool isDecoded = false;
+
+        GE::forEachType<GE::AssetPathTypes>([&]<typename AssetPathT>() {
+            if (isDecoded || type != GE::AssetPathYamlTraits<AssetPathT>::assetTypeStr)
+                return;
+
+            rhs = AssetPathT(path);
+            isDecoded = true;
+        });
+
+        return isDecoded;
     }
 };
 

--- a/include/Game-Engine/Components.hpp
+++ b/include/Game-Engine/Components.hpp
@@ -344,18 +344,7 @@ struct convert<GE::ScriptValue>
         Node node;
         std::visit([&](const auto& value) {
             using T = std::remove_cvref_t<decltype(value)>;
-            if constexpr (std::is_same_v<T, bool>)
-                node["type"] = "bool";
-            else if constexpr (std::is_same_v<T, int64_t>)
-                node["type"] = "int";
-            else if constexpr (std::is_same_v<T, float>)
-                node["type"] = "float";
-            else if constexpr (std::is_same_v<T, glm::vec2>)
-                node["type"] = "vec2";
-            else if constexpr (std::is_same_v<T, glm::vec3>)
-                node["type"] = "vec3";
-            else if constexpr (std::is_same_v<T, std::string>)
-                node["type"] = "string";
+            node["type"] = std::string(GE::ScriptValueTraits<T>::typeName);
             node["data"] = value;
         }, rhs);
         return node;
@@ -368,22 +357,17 @@ struct convert<GE::ScriptValue>
 
         const std::string type = node["type"].as<std::string>();
         const Node data = node["data"];
-        if (type == "bool")
-            rhs = data.as<bool>();
-        else if (type == "int")
-            rhs = data.as<int64_t>();
-        else if (type == "float")
-            rhs = data.as<float>();
-        else if (type == "vec2")
-            rhs = data.as<glm::vec2>();
-        else if (type == "vec3")
-            rhs = data.as<glm::vec3>();
-        else if (type == "string")
-            rhs = data.as<std::string>();
-        else
-            return false;
+        bool isDecoded = false;
 
-        return true;
+        GE::forEachType<GE::ScriptValueTypes>([&]<typename ValueT>() {
+            if (isDecoded || type != GE::ScriptValueTraits<ValueT>::typeName)
+                return;
+
+            rhs = data.as<ValueT>();
+            isDecoded = true;
+        });
+
+        return isDecoded;
     }
 };
 

--- a/include/Game-Engine/Components.hpp
+++ b/include/Game-Engine/Components.hpp
@@ -102,7 +102,7 @@ struct MeshComponent
 struct ScriptComponent
 {
     std::string name;
-    std::map<std::string, ScriptValue> parameters;
+    std::map<std::string, VScriptValue> parameters;
     std::shared_ptr<Script> instance;
 };
 
@@ -337,20 +337,20 @@ struct convert<GE::MeshComponent>
 };
 
 template<>
-struct convert<GE::ScriptValue>
+struct convert<GE::VScriptValue>
 {
-    static Node encode(const GE::ScriptValue& rhs)
+    static Node encode(const GE::VScriptValue& rhs)
     {
         Node node;
         std::visit([&](const auto& value) {
             using T = std::remove_cvref_t<decltype(value)>;
-            node["type"] = std::string(GE::ScriptValueTraits<T>::typeName);
+            node["type"] = std::string(GE::ScriptValueTraits<T>::name);
             node["data"] = value;
         }, rhs);
         return node;
     }
 
-    static bool decode(const Node& node, GE::ScriptValue& rhs)
+    static bool decode(const Node& node, GE::VScriptValue& rhs)
     {
         if (!node.IsMap() || !node["type"] || !node["data"])
             return false;
@@ -360,7 +360,7 @@ struct convert<GE::ScriptValue>
         bool isDecoded = false;
 
         GE::forEachType<GE::ScriptValueTypes>([&]<typename ValueT>() {
-            if (isDecoded || type != GE::ScriptValueTraits<ValueT>::typeName)
+            if (isDecoded || type != GE::ScriptValueTraits<ValueT>::name)
                 return;
 
             rhs = data.as<ValueT>();
@@ -388,7 +388,7 @@ struct convert<GE::ScriptComponent>
             return false;
 
         rhs.name = node["name"].as<std::string>();
-        rhs.parameters = node["parameters"] ? node["parameters"].as<std::map<std::string, GE::ScriptValue>>() : std::map<std::string, GE::ScriptValue>();
+        rhs.parameters = node["parameters"] ? node["parameters"].as<std::map<std::string, GE::VScriptValue>>() : std::map<std::string, GE::VScriptValue>();
         return true;
     }
 };

--- a/include/Game-Engine/Components.hpp
+++ b/include/Game-Engine/Components.hpp
@@ -22,6 +22,8 @@
 #include <map>
 #include <memory>
 #include <type_traits>
+#include <tuple>
+#include <utility>
 #include <variant>
 
 #include <yaml-cpp/yaml.h>
@@ -105,7 +107,47 @@ struct ScriptComponent
     std::shared_ptr<Script> instance;
 };
 
-using ComponentVariant = std::variant<NameComponent, HierarchyComponent, TransformComponent, CameraComponent, LightComponent, MeshComponent, ScriptComponent>;
+using ECSComponentTypes = std::tuple<NameComponent, HierarchyComponent, TransformComponent, CameraComponent, LightComponent, MeshComponent, ScriptComponent>;
+
+template<typename T>
+struct TupleToVariant;
+
+template<typename... Ts>
+struct TupleToVariant<std::tuple<Ts...>>
+{
+    using type = std::variant<Ts...>;
+};
+
+template<typename T>
+using TupleToVariant_t = typename TupleToVariant<T>::type;
+
+using ComponentVariant = TupleToVariant_t<ECSComponentTypes>;
+
+template<typename Fn, typename... Ts>
+inline constexpr void forEachECSComponentTypeImpl(Fn&& fn, std::tuple<Ts...>*)
+{
+    auto&& callback = fn;
+    (callback.template operator()<Ts>(), ...);
+}
+
+template<typename Fn>
+inline constexpr void forEachECSComponentType(Fn&& fn)
+{
+    forEachECSComponentTypeImpl(std::forward<Fn>(fn), static_cast<ECSComponentTypes*>(nullptr));
+}
+
+template<typename Fn, typename... Ts>
+inline constexpr bool anyECSComponentTypeImpl(Fn&& fn, std::tuple<Ts...>*)
+{
+    auto&& callback = fn;
+    return (callback.template operator()<Ts>() || ...);
+}
+
+template<typename Fn>
+inline constexpr bool anyECSComponentType(Fn&& fn)
+{
+    return anyECSComponentTypeImpl(std::forward<Fn>(fn), static_cast<ECSComponentTypes*>(nullptr));
+}
 
 template<> struct ECSComponentYamlTraits<NameComponent>      { static constexpr std::string_view name = "NameComponent";      };
 template<> struct ECSComponentYamlTraits<HierarchyComponent> { static constexpr std::string_view name = "HierarchyComponent"; };
@@ -431,25 +473,13 @@ struct convert<GE::ComponentVariant>
 
         const std::string type = node["type"].as<std::string>();
         const Node data = node["data"];
+        return GE::anyECSComponentType([&]<typename ComponentT>() {
+            if (type != GE::ECSComponentYamlTraits<ComponentT>::name)
+                return false;
 
-        if (type == "NameComponent")
-            rhs = data.as<GE::NameComponent>();
-        else if (type == "HierarchyComponent")
-            rhs = data.as<GE::HierarchyComponent>();
-        else if (type == "TransformComponent")
-            rhs = data.as<GE::TransformComponent>();
-        else if (type == "CameraComponent")
-            rhs = data.as<GE::CameraComponent>();
-        else if (type == "LightComponent")
-            rhs = data.as<GE::LightComponent>();
-        else if (type == "MeshComponent")
-            rhs = data.as<GE::MeshComponent>();
-        else if (type == "ScriptComponent")
-            rhs = data.as<GE::ScriptComponent>();
-        else
-            return false;
-
-        return true;
+            rhs = data.as<ComponentT>();
+            return true;
+        });
     }
 };
 

--- a/include/Game-Engine/Components.hpp
+++ b/include/Game-Engine/Components.hpp
@@ -13,6 +13,7 @@
 #include "Game-Engine/AssetManagerView.hpp"
 #include "Game-Engine/ECSWorld.hpp"
 #include "Game-Engine/Script.hpp"
+#include "Game-Engine/TypeList.hpp"
 
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
@@ -22,8 +23,6 @@
 #include <map>
 #include <memory>
 #include <type_traits>
-#include <tuple>
-#include <utility>
 #include <variant>
 
 #include <yaml-cpp/yaml.h>
@@ -107,47 +106,8 @@ struct ScriptComponent
     std::shared_ptr<Script> instance;
 };
 
-using ECSComponentTypes = std::tuple<NameComponent, HierarchyComponent, TransformComponent, CameraComponent, LightComponent, MeshComponent, ScriptComponent>;
-
-template<typename T>
-struct TupleToVariant;
-
-template<typename... Ts>
-struct TupleToVariant<std::tuple<Ts...>>
-{
-    using type = std::variant<Ts...>;
-};
-
-template<typename T>
-using TupleToVariant_t = typename TupleToVariant<T>::type;
-
-using ComponentVariant = TupleToVariant_t<ECSComponentTypes>;
-
-template<typename Fn, typename... Ts>
-inline constexpr void forEachECSComponentTypeImpl(Fn&& fn, std::tuple<Ts...>*)
-{
-    auto&& callback = fn;
-    (callback.template operator()<Ts>(), ...);
-}
-
-template<typename Fn>
-inline constexpr void forEachECSComponentType(Fn&& fn)
-{
-    forEachECSComponentTypeImpl(std::forward<Fn>(fn), static_cast<ECSComponentTypes*>(nullptr));
-}
-
-template<typename Fn, typename... Ts>
-inline constexpr bool anyECSComponentTypeImpl(Fn&& fn, std::tuple<Ts...>*)
-{
-    auto&& callback = fn;
-    return (callback.template operator()<Ts>() || ...);
-}
-
-template<typename Fn>
-inline constexpr bool anyECSComponentType(Fn&& fn)
-{
-    return anyECSComponentTypeImpl(std::forward<Fn>(fn), static_cast<ECSComponentTypes*>(nullptr));
-}
+using ECSComponentTypes = TypeList<NameComponent, HierarchyComponent, TransformComponent, CameraComponent, LightComponent, MeshComponent, ScriptComponent>;
+using ComponentVariant = ECSComponentTypes::into<std::variant>;
 
 template<> struct ECSComponentYamlTraits<NameComponent>      { static constexpr std::string_view name = "NameComponent";      };
 template<> struct ECSComponentYamlTraits<HierarchyComponent> { static constexpr std::string_view name = "HierarchyComponent"; };
@@ -473,7 +433,7 @@ struct convert<GE::ComponentVariant>
 
         const std::string type = node["type"].as<std::string>();
         const Node data = node["data"];
-        return GE::anyECSComponentType([&]<typename ComponentT>() {
+        return GE::anyType<GE::ECSComponentTypes>([&]<typename ComponentT>() {
             if (type != GE::ECSComponentYamlTraits<ComponentT>::name)
                 return false;
 

--- a/include/Game-Engine/Components.hpp
+++ b/include/Game-Engine/Components.hpp
@@ -433,13 +433,17 @@ struct convert<GE::ComponentVariant>
 
         const std::string type = node["type"].as<std::string>();
         const Node data = node["data"];
-        return GE::anyType<GE::ECSComponentTypes>([&]<typename ComponentT>() {
-            if (type != GE::ECSComponentYamlTraits<ComponentT>::name)
-                return false;
+        bool isDecoded = false;
+
+        GE::forEachType<GE::ECSComponentTypes>([&]<typename ComponentT>() {
+            if (isDecoded || type != GE::ECSComponentYamlTraits<ComponentT>::name)
+                return;
 
             rhs = data.as<ComponentT>();
-            return true;
+            isDecoded = true;
         });
+
+        return isDecoded;
     }
 };
 

--- a/include/Game-Engine/Input.hpp
+++ b/include/Game-Engine/Input.hpp
@@ -99,7 +99,7 @@ struct Input
     }
 };
 
-using VInput = std::variant<ActionInput, StateInput, RangeInput, Range2DInput>;
+using VInput = InputTypes::into<std::variant>;
 
 }
 

--- a/include/Game-Engine/InputFwd.hpp
+++ b/include/Game-Engine/InputFwd.hpp
@@ -9,6 +9,8 @@
 #ifndef INPUTFWD_HPP
 #define INPUTFWD_HPP
 
+#include "Game-Engine/TypeList.hpp"
+
 #include <glm/glm.hpp>
 
 #include <type_traits>
@@ -38,6 +40,8 @@ using ActionInput  = Input<InputClass::action>;
 using StateInput   = Input<InputClass::state>;
 using RangeInput   = Input<InputClass::state, float>;
 using Range2DInput = Input<InputClass::state, glm::vec2>;
+
+using InputTypes = TypeList<ActionInput, StateInput, RangeInput, Range2DInput>;
 
 }
 

--- a/include/Game-Engine/InputMapper.hpp
+++ b/include/Game-Engine/InputMapper.hpp
@@ -23,7 +23,6 @@ namespace GE
 {
 
 template<RawInput RI, InputType I> struct InputMapper;
-template<RawInput RI, typename TList> struct InputMapperTypeList;
 
 template<>
 struct GE_API InputMapper<KeyboardButton, ActionInput>
@@ -102,16 +101,10 @@ struct GE_API InputMapper<KeyboardButton, Range2DInput>
     void onInputEvent(InputEvent& event);
 };
 
-template<RawInput RI, typename... Ts>
-struct InputMapperTypeList<RI, TypeList<Ts...>>
-{
-    using type = TypeList<InputMapper<RI, Ts>...>;
-};
+template<typename InputT>
+using KeyboardButtonInputMapper = InputMapper<KeyboardButton, InputT>;
 
-template<RawInput RI, typename TList>
-using InputMapperTypeList_t = typename InputMapperTypeList<RI, TList>::type;
-
-using InputMapperTypes = InputMapperTypeList_t<KeyboardButton, InputTypes>;
+using InputMapperTypes = TypeListMap_t<InputTypes, KeyboardButtonInputMapper>;
 
 using VInputMapper = InputMapperTypes::into<std::variant>;
 

--- a/include/Game-Engine/InputMapper.hpp
+++ b/include/Game-Engine/InputMapper.hpp
@@ -13,6 +13,7 @@
 #include "Game-Engine/Event.hpp"
 #include "Game-Engine/InputFwd.hpp"
 #include "Game-Engine/RawInput.hpp"
+#include "Game-Engine/TypeList.hpp"
 
 #include <glm/glm.hpp>
 
@@ -100,12 +101,14 @@ struct GE_API InputMapper<KeyboardButton, Range2DInput>
     void onInputEvent(InputEvent& event);
 };
 
-using VInputMapper = std::variant<
+using InputMapperTypes = TypeList<
     InputMapper<KeyboardButton, ActionInput>,
     InputMapper<KeyboardButton, StateInput>,
     InputMapper<KeyboardButton, RangeInput>,
     InputMapper<KeyboardButton, Range2DInput>
 >;
+
+using VInputMapper = InputMapperTypes::into<std::variant>;
 
 }
 

--- a/include/Game-Engine/InputMapper.hpp
+++ b/include/Game-Engine/InputMapper.hpp
@@ -23,6 +23,7 @@ namespace GE
 {
 
 template<RawInput RI, InputType I> struct InputMapper;
+template<RawInput RI, typename TList> struct InputMapperTypeList;
 
 template<>
 struct GE_API InputMapper<KeyboardButton, ActionInput>
@@ -101,12 +102,16 @@ struct GE_API InputMapper<KeyboardButton, Range2DInput>
     void onInputEvent(InputEvent& event);
 };
 
-using InputMapperTypes = TypeList<
-    InputMapper<KeyboardButton, ActionInput>,
-    InputMapper<KeyboardButton, StateInput>,
-    InputMapper<KeyboardButton, RangeInput>,
-    InputMapper<KeyboardButton, Range2DInput>
->;
+template<RawInput RI, typename... Ts>
+struct InputMapperTypeList<RI, TypeList<Ts...>>
+{
+    using type = TypeList<InputMapper<RI, Ts>...>;
+};
+
+template<RawInput RI, typename TList>
+using InputMapperTypeList_t = typename InputMapperTypeList<RI, TList>::type;
+
+using InputMapperTypes = InputMapperTypeList_t<KeyboardButton, InputTypes>;
 
 using VInputMapper = InputMapperTypes::into<std::variant>;
 

--- a/include/Game-Engine/InputMapper.hpp
+++ b/include/Game-Engine/InputMapper.hpp
@@ -104,7 +104,7 @@ struct GE_API InputMapper<KeyboardButton, Range2DInput>
 template<typename InputT>
 using KeyboardButtonInputMapper = InputMapper<KeyboardButton, InputT>;
 
-using InputMapperTypes = TypeListMap_t<InputTypes, KeyboardButtonInputMapper>;
+using InputMapperTypes = InputTypes::wrapped<KeyboardButtonInputMapper>;
 
 using VInputMapper = InputMapperTypes::into<std::variant>;
 

--- a/include/Game-Engine/Script.hpp
+++ b/include/Game-Engine/Script.hpp
@@ -11,6 +11,7 @@
 
 #include "Game-Engine/ECSWorld.hpp"
 #include "Game-Engine/Export.hpp"
+#include "Game-Engine/TypeList.hpp"
 
 #include <glm/glm.hpp>
 
@@ -33,15 +34,11 @@ template<ECSWorldLike ECSWorldT>
 struct basic_entity;
 using Entity = basic_entity<ECSWorld>;
 
-using ScriptValue = std::variant<bool, int64_t, float, glm::vec2, glm::vec3, std::string>;
+using ScriptValueTypes = TypeList<bool, int64_t, float, glm::vec2, glm::vec3, std::string>;
+using ScriptValue = ScriptValueTypes::into<std::variant>;
 
 template<typename T>
-concept ScriptValueType = std::same_as<std::remove_cvref_t<T>, bool>
-                          || std::same_as<std::remove_cvref_t<T>, int64_t>
-                          || std::same_as<std::remove_cvref_t<T>, float>
-                          || std::same_as<std::remove_cvref_t<T>, glm::vec2>
-                          || std::same_as<std::remove_cvref_t<T>, glm::vec3>
-                          || std::same_as<std::remove_cvref_t<T>, std::string>;
+concept ScriptValueType = IsTypeInList<std::remove_cvref_t<T>, ScriptValueTypes>;
 
 struct ScriptParameterDescriptor
 {

--- a/include/Game-Engine/Script.hpp
+++ b/include/Game-Engine/Script.hpp
@@ -36,7 +36,7 @@ struct basic_entity;
 using Entity = basic_entity<ECSWorld>;
 
 using ScriptValueTypes = TypeList<bool, int64_t, float, glm::vec2, glm::vec3, std::string>;
-using ScriptValue = ScriptValueTypes::into<std::variant>;
+using VScriptValue = ScriptValueTypes::into<std::variant>;
 
 template<typename T>
 concept ScriptValueType = IsTypeInList<std::remove_cvref_t<T>, ScriptValueTypes>;
@@ -44,19 +44,19 @@ concept ScriptValueType = IsTypeInList<std::remove_cvref_t<T>, ScriptValueTypes>
 template<typename T>
 struct ScriptValueTraits;
 
-template<> struct ScriptValueTraits<bool>        { static constexpr std::string_view typeName = "bool"; };
-template<> struct ScriptValueTraits<int64_t>     { static constexpr std::string_view typeName = "int"; };
-template<> struct ScriptValueTraits<float>       { static constexpr std::string_view typeName = "float"; };
-template<> struct ScriptValueTraits<glm::vec2>   { static constexpr std::string_view typeName = "vec2"; };
-template<> struct ScriptValueTraits<glm::vec3>   { static constexpr std::string_view typeName = "vec3"; };
-template<> struct ScriptValueTraits<std::string> { static constexpr std::string_view typeName = "string"; };
+template<> struct ScriptValueTraits<bool>        { static constexpr std::string_view name = "bool"; };
+template<> struct ScriptValueTraits<int64_t>     { static constexpr std::string_view name = "int"; };
+template<> struct ScriptValueTraits<float>       { static constexpr std::string_view name = "float"; };
+template<> struct ScriptValueTraits<glm::vec2>   { static constexpr std::string_view name = "vec2"; };
+template<> struct ScriptValueTraits<glm::vec3>   { static constexpr std::string_view name = "vec3"; };
+template<> struct ScriptValueTraits<std::string> { static constexpr std::string_view name = "string"; };
 
 struct ScriptParameterDescriptor
 {
     std::string name;
-    ScriptValue defaultValue;
-    std::function<ScriptValue(const Script&)> get;
-    std::function<void(Script&, const ScriptValue&)> set;
+    VScriptValue defaultValue;
+    std::function<VScriptValue(const Script&)> get;
+    std::function<void(Script&, const VScriptValue&)> set;
 };
 
 class GE_API Script
@@ -102,11 +102,11 @@ public:
     {
         m_parameters[scriptName].push_back(ScriptParameterDescriptor{
             .name = std::move(parameterName),
-            .defaultValue = ScriptValue(defaultValue),
-            .get = [member](const Script& script) -> ScriptValue {
+            .defaultValue = VScriptValue(defaultValue),
+            .get = [member](const Script& script) -> VScriptValue {
                 return static_cast<const ScriptT&>(script).*member;
             },
-            .set = [member](Script& script, const ScriptValue& value) {
+            .set = [member](Script& script, const VScriptValue& value) {
                 static_cast<ScriptT&>(script).*member = std::get<ValueT>(value);
             }
         });

--- a/include/Game-Engine/Script.hpp
+++ b/include/Game-Engine/Script.hpp
@@ -24,6 +24,7 @@
 #include <utility>
 #include <variant>
 #include <vector>
+#include <string_view>
 
 namespace GE
 {
@@ -39,6 +40,16 @@ using ScriptValue = ScriptValueTypes::into<std::variant>;
 
 template<typename T>
 concept ScriptValueType = IsTypeInList<std::remove_cvref_t<T>, ScriptValueTypes>;
+
+template<typename T>
+struct ScriptValueTraits;
+
+template<> struct ScriptValueTraits<bool>        { static constexpr std::string_view typeName = "bool"; };
+template<> struct ScriptValueTraits<int64_t>     { static constexpr std::string_view typeName = "int"; };
+template<> struct ScriptValueTraits<float>       { static constexpr std::string_view typeName = "float"; };
+template<> struct ScriptValueTraits<glm::vec2>   { static constexpr std::string_view typeName = "vec2"; };
+template<> struct ScriptValueTraits<glm::vec3>   { static constexpr std::string_view typeName = "vec3"; };
+template<> struct ScriptValueTraits<std::string> { static constexpr std::string_view typeName = "string"; };
 
 struct ScriptParameterDescriptor
 {

--- a/include/Game-Engine/TypeList.hpp
+++ b/include/Game-Engine/TypeList.hpp
@@ -21,6 +21,9 @@ struct TypeList
 {
     template<template<typename...> typename Container>
     using into = Container<Ts...>;
+
+    template<template<typename> typename WrappedType>
+    using wrapped = TypeList<WrappedType<Ts>...>;
 };
 
 template<typename T, typename TList>
@@ -34,17 +37,17 @@ struct TypeListContains<T, TypeList<Ts...>> : std::bool_constant<(std::is_same_v
 template<typename T, typename TList>
 concept IsTypeInList = TypeListContains<T, TList>::value;
 
-template<typename TList, template<typename> typename Mapper>
-struct TypeListMap;
+template<typename TList, template<typename> typename WrappedType>
+struct TypeListWrap;
 
-template<typename... Ts, template<typename> typename Mapper>
-struct TypeListMap<TypeList<Ts...>, Mapper>
+template<typename... Ts, template<typename> typename WrappedType>
+struct TypeListWrap<TypeList<Ts...>, WrappedType>
 {
-    using type = TypeList<Mapper<Ts>...>;
+    using type = TypeList<WrappedType<Ts>...>;
 };
 
-template<typename TList, template<typename> typename Mapper>
-using TypeListMap_t = typename TypeListMap<TList, Mapper>::type;
+template<typename TList, template<typename> typename WrappedType>
+using TypeListWrap_t = typename TypeListWrap<TList, WrappedType>::type;
 
 template<typename TList, typename Fn>
 inline constexpr void forEachType(Fn&& fn);
@@ -53,6 +56,7 @@ template<typename... Ts, typename Fn>
 inline constexpr void forEachType(TypeList<Ts...>, Fn&& fn)
 {
     auto&& callback = fn;
+    static_assert((std::is_void_v<decltype(callback.template operator()<Ts>())> && ...), "forEachType callback must return void.");
     (callback.template operator()<Ts>(), ...);
 }
 
@@ -60,6 +64,55 @@ template<typename TList, typename Fn>
 inline constexpr void forEachType(Fn&& fn)
 {
     forEachType(TList{}, std::forward<Fn>(fn));
+}
+
+template<typename TList, typename Fn>
+inline constexpr bool anyOfType(Fn&& fn);
+
+template<typename... Ts, typename Fn>
+inline constexpr bool anyOfType(TypeList<Ts...>, Fn&& fn)
+{
+    auto&& callback = fn;
+    static_assert((std::is_convertible_v<decltype(callback.template operator()<Ts>()), bool> && ...), "anyOfType callback must return bool-convertible values.");
+    return (static_cast<bool>(callback.template operator()<Ts>()) || ...);
+}
+
+template<typename TList, typename Fn>
+inline constexpr bool anyOfType(Fn&& fn)
+{
+    return anyOfType(TList{}, std::forward<Fn>(fn));
+}
+
+template<typename TList, typename Fn>
+inline constexpr bool allOfType(Fn&& fn);
+
+template<typename... Ts, typename Fn>
+inline constexpr bool allOfType(TypeList<Ts...>, Fn&& fn)
+{
+    auto&& callback = fn;
+    static_assert((std::is_convertible_v<decltype(callback.template operator()<Ts>()), bool> && ...), "allOfType callback must return bool-convertible values.");
+    return (static_cast<bool>(callback.template operator()<Ts>()) && ...);
+}
+
+template<typename TList, typename Fn>
+inline constexpr bool allOfType(Fn&& fn)
+{
+    return allOfType(TList{}, std::forward<Fn>(fn));
+}
+
+template<typename TList, typename Fn>
+inline constexpr bool noneOfType(Fn&& fn);
+
+template<typename... Ts, typename Fn>
+inline constexpr bool noneOfType(TypeList<Ts...>, Fn&& fn)
+{
+    return !anyOfType(TypeList<Ts...>{}, std::forward<Fn>(fn));
+}
+
+template<typename TList, typename Fn>
+inline constexpr bool noneOfType(Fn&& fn)
+{
+    return noneOfType(TList{}, std::forward<Fn>(fn));
 }
 
 } // namespace GE

--- a/include/Game-Engine/TypeList.hpp
+++ b/include/Game-Engine/TypeList.hpp
@@ -1,0 +1,71 @@
+/*
+ * ---------------------------------------------------
+ * TypeList.hpp
+ *
+ * Author: Thomas Choquet <semoir.dense-0h@icloud.com>
+ * Date: 2026/04/26
+ * ---------------------------------------------------
+ */
+
+#ifndef TYPELIST_HPP
+#define TYPELIST_HPP
+
+#include <type_traits>
+#include <utility>
+
+namespace GE
+{
+
+template<typename... Ts>
+struct TypeList
+{
+    template<template<typename...> typename Container>
+    using into = Container<Ts...>;
+};
+
+template<typename T, typename TList>
+struct TypeListContains;
+
+template<typename T, typename... Ts>
+struct TypeListContains<T, TypeList<Ts...>> : std::bool_constant<(std::is_same_v<T, Ts> || ...)>
+{
+};
+
+template<typename T, typename TList>
+concept IsTypeInList = TypeListContains<T, TList>::value;
+
+template<typename TList, typename Fn>
+inline constexpr void forEachType(Fn&& fn);
+
+template<typename... Ts, typename Fn>
+inline constexpr void forEachType(TypeList<Ts...>, Fn&& fn)
+{
+    auto&& callback = fn;
+    (callback.template operator()<Ts>(), ...);
+}
+
+template<typename TList, typename Fn>
+inline constexpr void forEachType(Fn&& fn)
+{
+    forEachType(TList{}, std::forward<Fn>(fn));
+}
+
+template<typename TList, typename Fn>
+inline constexpr bool anyType(Fn&& fn);
+
+template<typename... Ts, typename Fn>
+inline constexpr bool anyType(TypeList<Ts...>, Fn&& fn)
+{
+    auto&& callback = fn;
+    return (callback.template operator()<Ts>() || ...);
+}
+
+template<typename TList, typename Fn>
+inline constexpr bool anyType(Fn&& fn)
+{
+    return anyType(TList{}, std::forward<Fn>(fn));
+}
+
+} // namespace GE
+
+#endif // TYPELIST_HPP

--- a/include/Game-Engine/TypeList.hpp
+++ b/include/Game-Engine/TypeList.hpp
@@ -34,6 +34,18 @@ struct TypeListContains<T, TypeList<Ts...>> : std::bool_constant<(std::is_same_v
 template<typename T, typename TList>
 concept IsTypeInList = TypeListContains<T, TList>::value;
 
+template<typename TList, template<typename> typename Mapper>
+struct TypeListMap;
+
+template<typename... Ts, template<typename> typename Mapper>
+struct TypeListMap<TypeList<Ts...>, Mapper>
+{
+    using type = TypeList<Mapper<Ts>...>;
+};
+
+template<typename TList, template<typename> typename Mapper>
+using TypeListMap_t = typename TypeListMap<TList, Mapper>::type;
+
 template<typename TList, typename Fn>
 inline constexpr void forEachType(Fn&& fn);
 

--- a/include/Game-Engine/TypeList.hpp
+++ b/include/Game-Engine/TypeList.hpp
@@ -37,82 +37,40 @@ struct TypeListContains<T, TypeList<Ts...>> : std::bool_constant<(std::is_same_v
 template<typename T, typename TList>
 concept IsTypeInList = TypeListContains<T, TList>::value;
 
-template<typename TList, template<typename> typename WrappedType>
-struct TypeListWrap;
-
-template<typename... Ts, template<typename> typename WrappedType>
-struct TypeListWrap<TypeList<Ts...>, WrappedType>
-{
-    using type = TypeList<WrappedType<Ts>...>;
-};
-
-template<typename TList, template<typename> typename WrappedType>
-using TypeListWrap_t = typename TypeListWrap<TList, WrappedType>::type;
-
-template<typename TList, typename Fn>
-inline constexpr void forEachType(Fn&& fn);
-
-template<typename... Ts, typename Fn>
-inline constexpr void forEachType(TypeList<Ts...>, Fn&& fn)
-{
-    auto&& callback = fn;
-    static_assert((std::is_void_v<decltype(callback.template operator()<Ts>())> && ...), "forEachType callback must return void.");
-    (callback.template operator()<Ts>(), ...);
-}
-
 template<typename TList, typename Fn>
 inline constexpr void forEachType(Fn&& fn)
 {
-    forEachType(TList{}, std::forward<Fn>(fn));
-}
-
-template<typename TList, typename Fn>
-inline constexpr bool anyOfType(Fn&& fn);
-
-template<typename... Ts, typename Fn>
-inline constexpr bool anyOfType(TypeList<Ts...>, Fn&& fn)
-{
-    auto&& callback = fn;
-    static_assert((std::is_convertible_v<decltype(callback.template operator()<Ts>()), bool> && ...), "anyOfType callback must return bool-convertible values.");
-    return (static_cast<bool>(callback.template operator()<Ts>()) || ...);
+    [&]<typename... Ts>(TypeList<Ts...>) {
+        auto&& callback = fn;
+        static_assert((std::is_void_v<decltype(callback.template operator()<Ts>())> && ...), "forEachType callback must return void.");
+        (callback.template operator()<Ts>(), ...);
+    }(TList{});
 }
 
 template<typename TList, typename Fn>
 inline constexpr bool anyOfType(Fn&& fn)
 {
-    return anyOfType(TList{}, std::forward<Fn>(fn));
-}
-
-template<typename TList, typename Fn>
-inline constexpr bool allOfType(Fn&& fn);
-
-template<typename... Ts, typename Fn>
-inline constexpr bool allOfType(TypeList<Ts...>, Fn&& fn)
-{
-    auto&& callback = fn;
-    static_assert((std::is_convertible_v<decltype(callback.template operator()<Ts>()), bool> && ...), "allOfType callback must return bool-convertible values.");
-    return (static_cast<bool>(callback.template operator()<Ts>()) && ...);
+    return [&]<typename... Ts>(TypeList<Ts...>) {
+        auto&& callback = fn;
+        static_assert((std::is_convertible_v<decltype(callback.template operator()<Ts>()), bool> && ...), "anyOfType callback must return bool-convertible values.");
+        return (static_cast<bool>(callback.template operator()<Ts>()) || ...);
+    }(TList{});
 }
 
 template<typename TList, typename Fn>
 inline constexpr bool allOfType(Fn&& fn)
 {
-    return allOfType(TList{}, std::forward<Fn>(fn));
-}
-
-template<typename TList, typename Fn>
-inline constexpr bool noneOfType(Fn&& fn);
-
-template<typename... Ts, typename Fn>
-inline constexpr bool noneOfType(TypeList<Ts...>, Fn&& fn)
-{
-    return !anyOfType(TypeList<Ts...>{}, std::forward<Fn>(fn));
+    return [&]<typename... Ts>(TypeList<Ts...>) {
+        auto&& callback = fn;
+        static_assert((std::is_convertible_v<decltype(callback.template operator()<Ts>()), bool> && ...), "allOfType callback must return bool-convertible values.");
+        return (static_cast<bool>(callback.template operator()<Ts>()) && ...);
+    }(TList{});
 }
 
 template<typename TList, typename Fn>
 inline constexpr bool noneOfType(Fn&& fn)
 {
-    return noneOfType(TList{}, std::forward<Fn>(fn));
+    return !anyOfType<TList>(std::forward<Fn>(fn));
 }
 
 } // namespace GE

--- a/include/Game-Engine/TypeList.hpp
+++ b/include/Game-Engine/TypeList.hpp
@@ -50,22 +50,6 @@ inline constexpr void forEachType(Fn&& fn)
     forEachType(TList{}, std::forward<Fn>(fn));
 }
 
-template<typename TList, typename Fn>
-inline constexpr bool anyType(Fn&& fn);
-
-template<typename... Ts, typename Fn>
-inline constexpr bool anyType(TypeList<Ts...>, Fn&& fn)
-{
-    auto&& callback = fn;
-    return (callback.template operator()<Ts>() || ...);
-}
-
-template<typename TList, typename Fn>
-inline constexpr bool anyType(Fn&& fn)
-{
-    return anyType(TList{}, std::forward<Fn>(fn));
-}
-
 } // namespace GE
 
 #endif // TYPELIST_HPP

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -63,7 +63,7 @@ Scene::Descriptor Scene::makeDescriptor() const
         std::vector<ComponentVariant> components;
         const_Entity entity{&m_ecsWorld, entityId};
 
-        forEachECSComponentType([&]<typename ComponentT>() {
+        forEachType<ECSComponentTypes>([&]<typename ComponentT>() {
             if (!entity.has<ComponentT>())
                 return;
 

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -63,24 +63,18 @@ Scene::Descriptor Scene::makeDescriptor() const
         std::vector<ComponentVariant> components;
         const_Entity entity{&m_ecsWorld, entityId};
 
-        if (entity.has<NameComponent>())
-            components.emplace_back(entity.get<NameComponent>());
-        if (entity.has<HierarchyComponent>())
-            components.emplace_back(entity.get<HierarchyComponent>());
-        if (entity.has<TransformComponent>())
-            components.emplace_back(entity.get<TransformComponent>());
-        if (entity.has<CameraComponent>())
-            components.emplace_back(entity.get<CameraComponent>());
-        if (entity.has<LightComponent>())
-            components.emplace_back(entity.get<LightComponent>());
-        if (entity.has<MeshComponent>())
-            components.emplace_back(entity.get<MeshComponent>());
-        if (entity.has<ScriptComponent>()) {
-            ScriptComponent scriptComponent = entity.get<ScriptComponent>();
-            // TODO find a solution to not have to do that
-            scriptComponent.instance.reset();
-            components.emplace_back(std::move(scriptComponent));
-        }
+        forEachECSComponentType([&]<typename ComponentT>() {
+            if (!entity.has<ComponentT>())
+                return;
+
+            if constexpr (std::is_same_v<ComponentT, ScriptComponent>) {
+                ScriptComponent scriptComponent = entity.get<ScriptComponent>();
+                // TODO find a solution to not have to do that
+                scriptComponent.instance.reset();
+                components.emplace_back(std::move(scriptComponent));
+            } else
+                components.emplace_back(entity.get<ComponentT>());
+        });
 
         desc.entities.emplace(entityId, std::move(components));
     }


### PR DESCRIPTION
### Motivation
- Centralize the list of ECS component types so adding/removing a component only requires a single update instead of multiple duplicated lists. 
- Replace manual `if/else` dispatch and repeated per-component codepaths with reusable compile-time iteration to reduce maintenance and human error.

### Description
- Introduce `ECSComponentTypes` as a single `std::tuple<...>` listing all components and derive `ComponentVariant` from it via a `TupleToVariant` helper template in `include/Game-Engine/Components.hpp`.
- Add compile-time iteration utilities `forEachECSComponentType` and `anyECSComponentType` to invoke a templated callback for every component type in the typelist.
- Replace the long manual chain in `YAML::convert<GE::ComponentVariant>::decode` with an `anyECSComponentType` loop that compares `ECSComponentYamlTraits<T>::name` and decodes the matching component type automatically.
- Replace the hardcoded checks in `Scene::makeDescriptor()` with `forEachECSComponentType`, preserving the special `ScriptComponent` `instance.reset()` handling; added includes for `<tuple>` and `<utility>`.

### Testing
- Attempted to configure with tests enabled using `cmake -S . -B build -DGE_BUILD_TESTS=ON`, but the build failed while fetching `googletest` due to network/proxy restrictions (HTTP 403) so tests could not run.
- Attempted a non-test build with `cmake -S . -B build-no-tests -DGE_BUILD_TESTS=OFF && cmake --build build-no-tests -j4`, but the fetch of the `Graphics` dependency failed for the same network reason (HTTP 403), so the build could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecda6b11288321bb21416709b52e67)